### PR TITLE
Add better UI for different errors on note page

### DIFF
--- a/app/notes/[noteId]/page.tsx
+++ b/app/notes/[noteId]/page.tsx
@@ -16,8 +16,7 @@ export default async function NotePage(props: Props) {
   const sessionTokenCookie = (await cookies()).get('sessionToken');
 
   // 2. Check if the note exists
-  const noteExists = await selectNoteExists(noteId);
-  if (!noteExists) {
+  if (!(await selectNoteExists(noteId))) {
     return (
       <div>
         <h1>Error loading note {noteId}</h1>

--- a/app/notes/[noteId]/page.tsx
+++ b/app/notes/[noteId]/page.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers';
 import Link from 'next/link';
-import { getNote } from '../../../database/notes';
+import { getNote, selectNoteExists } from '../../../database/notes';
 
 type Props = {
   params: Promise<{
@@ -10,19 +10,28 @@ type Props = {
 
 export default async function NotePage(props: Props) {
   // Task: Restrict access to the note page only to the user who created the note
+  const noteId = Number((await props.params).noteId);
 
   // 1. Checking if the sessionToken cookie exists
   const sessionTokenCookie = (await cookies()).get('sessionToken');
 
-  // 2. Query the note with the session token and noteId
-  const note =
-    sessionTokenCookie &&
-    (await getNote(
-      sessionTokenCookie.value,
-      Number((await props.params).noteId),
-    ));
+  // 2. Check if the note exists
+  const noteExists = await selectNoteExists(noteId);
+  if (!noteExists) {
+    return (
+      <div>
+        <h1>Error loading note {noteId}</h1>
+        <div>The note does not exist</div>
+        <Link href="/notes">Back to notes</Link>
+      </div>
+    );
+  }
 
-  // 3. If there is no note for the current user, show restricted access message
+  // 3. Query the note with the session token and noteId
+  const note =
+    sessionTokenCookie && (await getNote(sessionTokenCookie.value, noteId));
+
+  // 4. If there is no note for the current user, show restricted access message
   if (!note) {
     return (
       <div>
@@ -33,6 +42,7 @@ export default async function NotePage(props: Props) {
     );
   }
 
+  // 5. Finally display the notes created by the current user
   return (
     <div>
       <h1>{note.title}</h1>

--- a/database/notes.ts
+++ b/database/notes.ts
@@ -38,6 +38,21 @@ export const getNote = cache(
   },
 );
 
+export async function selectNoteExists(noteId: Note['id']) {
+  const [record] = await sql<{ exists: boolean }[]>`
+    SELECT
+      EXISTS (
+        SELECT
+          TRUE
+        FROM
+          notes
+        WHERE
+          id = ${noteId}
+      )
+  `;
+  return Boolean(record?.exists);
+}
+
 export const createNote = cache(
   async (
     sessionToken: Session['token'],


### PR DESCRIPTION
Ensure that the UI displayed to users reflects the exact condition of what is happening

When a user queries for a note that doesn't exist, we want to display a UI that shows this to the user instead of showing `Access Denied` in this case.