### PR TITLE
Add config for linting & typechecking disable for build

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,12 @@ const nextConfig: NextConfig = {
     dynamicIO: true,
     typedRoutes: true,
   },
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
+  typescript: {
+    ignoreBuildErrors: true,
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Add the configuration settings in Next.js config to disable linting and typecheck during building, as this is important for the CI/CD runs. We already have this in Next.js example but have not added it here